### PR TITLE
Enhancement: Run static code analysis with `phpstan/phpstan` on GitHub Actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/.github/                       export-ignore
+/.gitattributes                 export-ignore
+/phpstan-baseline.neon          export-ignore
+/phpstan.neon                   export-ignore

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,0 +1,57 @@
+# https://docs.github.com/en/actions
+
+name: "Integrate"
+
+on:
+  pull_request: null
+  push:
+    branches:
+      - "master"
+
+jobs:
+  static-code-analysis:
+    name: "Static Code Analysis"
+
+    runs-on: "ubuntu-latest"
+
+    timeout-minutes: 5
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.1"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3.5.3"
+
+      - name: "Set up PHP"
+        uses: "shivammathur/setup-php@2.25.5"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+
+      - name: "Set up problem matchers for PHP"
+        run: "echo \"::add-matcher::${{ runner.tool_cache }}/php.json\""
+
+      - name: "Validate composer.json and composer.lock"
+        run: "composer validate --ansi --strict"
+
+      - name: "Determine composer cache directory"
+        run: "echo \"COMPOSER_CACHE_DIR=$(composer config cache-dir}})\" >> $GITHUB_ENV"
+
+      - name: "Cache dependencies installed with composer"
+        uses: "actions/cache@v3.3.1"
+        with:
+          path: "${{ env.COMPOSER_CACHE_DIR }}"
+          key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
+
+      - name: "Install locked dependencies with composer"
+        run: "composer install --ansi --no-interaction --no-progress"
+
+      - name: "Create cache directory for phpstan/phpstan"
+        run: "mkdir -p .build/phpstan/"
+
+      - name: "Run phpstan/phpstan"
+        run: "vendor/bin/phpstan --ansi --configuration=phpstan.neon --memory-limit=-1"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.build/
 composer.phar
 /vendor
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bannerbear PHP Library
 
+[![Integrate](https://github.com/yongfook/bannerbear-php/workflows/Integrate/badge.svg)](https://github.com/yongfook/bannerbear-php/actions)
+
 A PHP wrapper for the Bannerbear API - an image and video generation service.
 
 ## Documentation

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,3 @@
+parameters:
+	ignoreErrors: []
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+	- phpstan-baseline.neon
+
+parameters:
+	level: 0
+
+	paths:
+		- src/
+
+	tmpDir: .build/phpstan/


### PR DESCRIPTION
This pull request

- [x] runs a static code analysis with `phpstan/phpstan` on GitHub Actions

Follows #3.

💁‍♂️ The workflow will not run unless merged into `master` - but you can see the workflow in action on my fork at https://github.com/localheinz/bannerbear-php/pull/1.